### PR TITLE
Initial version

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,58 @@
+version: "2"
+checks:
+  argument-count:
+    config:
+      threshold: 5
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 500
+  method-complexity:
+    enabled: false
+  method-count:
+    config:
+      threshold: 25
+  method-lines:
+    config:
+      threshold: 40
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+  identical-code:
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+plugins:
+  bandit:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        python:
+          mass_threshold: 40
+  fixme:
+    enabled: true
+  git-legal:
+    enabled: true
+  pylint:
+    enabled: true
+    channel: "beta"
+  radon:
+    enabled: true
+    config:
+      threshold: "C"
+  sonar-python:
+    enabled: true
+    config:
+      tests_patterns:
+        - tests/**
+exclude_patterns:
+- tests/

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
 
 # PyBuilder
 target/
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Offline version file
+mlx/__version__.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,320 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS, conf.py, __init__.py, setup.py
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=C0301, C0325, W0403, R0913, R0911, E0401
+#C0325 - disabled because we want to use print with parenthesis
+#C0301 - because line limit is checked by pep8 plugin
+#W0403 - because relative-imports are key inside unit-tests
+#R0913 - because the amount of arguments is checked by code climate
+#R0911 - because the amount of return statements is checked by code climate
+#E0401 - ignore import error because in code climate dependencies aren't installed
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input,file
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject,Object
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,16 @@ matrix:
   include:
     - python: 3.5
       env:
-        - TOXENV=py35,sphinx2.1,sphinx-latest,codecov
+        - TOXENV=py35,codecov
     - python: 3.6
       env:
-        - TOXENV=py36,sphinx2.1,sphinx-latest,codecov
+        - TOXENV=py36,codecov
     - python: 3.7
       env:
-        - TOXENV=py37,check,sphinx2.1,sphinx-latest,codecov
+        - TOXENV=py37,check,codecov
     - python: 3.8
       env:
-        - TOXENV=py38,check,sphinx2.1,sphinx-latest,codecov
+        - TOXENV=py38,check,codecov
 
 before_install:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,68 @@
+language: python
+sudo: false
+cache: pip
+dist: xenial
+
+matrix:
+  include:
+    - python: 3.5
+      env:
+        - TOXENV=py35,sphinx2.1,sphinx-latest,codecov
+    - python: 3.6
+      env:
+        - TOXENV=py36,sphinx2.1,sphinx-latest,codecov
+    - python: 3.7
+      env:
+        - TOXENV=py37,check,sphinx2.1,sphinx-latest,codecov
+    - python: 3.8
+      env:
+        - TOXENV=py38,check,sphinx2.1,sphinx-latest,codecov
+
+before_install:
+  - python --version
+  - uname -a
+  - lsb_release -a
+
+install:
+  - pip install tox
+  - pip install coverage
+  - virtualenv --version
+  - easy_install --version
+  - pip --version
+  - tox --version
+
+script:
+  - tox -v
+
+after_failure:
+  - more .tox/log/* | cat
+  - more .tox/*/log/* | cat
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always
+
+# Deploy: disable jekyll in order to publish subfolders with leading underscores as well to pages
+before_deploy:
+  - mkdir -p doc/_build/html/
+  - touch doc/_build/html/.nojekyll
+deploy:
+  # production pypi
+  - provider: pypi
+    distributions: sdist bdist_wheel
+    user: __token__
+    password:
+      secure: Rxqleh+i8jGyrtDSMqtmJwivfXFaeh3zQfc4nCrKTK+9xtCgl2Fr8Kxt7a20Vt4gCGPtrvxyT4MmGl2BW1CiWsSI8ysOvJ3qB3zfTPf8vksxpVz7djQt7dC4SoK+Htq2qVhuWZYzRWqJymsPu6slBBfJ4cbdxOoSDM8O/j72byOUrG1eZ/q1JBThz/3zzSIG7Zsr1Bmxd2EFSr5yWDwgEgZY8P8lPQi9SAUK8BO9guu7GZGfJkZS3K30ZDnyv1QKgR8t9xX8RcY3kX73qCkGJJG9RAoaL9cDuWJRs1qTw7baLbDJKTFPNNvli8nVqtg/flpAuAaiMzgbamwjrNDbpJuKlm3PTb++n1HeFXa+xx8Tt5BVEs2W0dG+e5+nuUsXxPpHiuBWCSHdUHdCaYxCd4GEkJOiB5IQjY1YXfo95+Q9eYnLfnL2duf3ao7J2LWdjIuJpnVDl4KG5iqMSQdTqOeJJXj3oIb7e2m5hcTpsf7JVBO3V5sswUt8d8dVDzE38c9jX80/tRsmhV2HQxPNyuQtT2d8JSV2kSZKoZW8A3PQhBnhcXZv7QuCifo2r7HG561xuB83WksdZ5FLIqt3qk72Syiz0FmRkucXoaXzNAc4CwMKFgzS6GD3fdt7kEV+sbt7tiGSKkNxb/enGZ37NcJKtGkItatnz+g0zLYi71Y=
+    on:
+      branch: master
+      python: 3.6
+      tags: true
+  # publish documentation: built by tox, published to pages
+  - provider: pages
+    skip_cleanup: true
+    local_dir: doc/_build/html/
+    github_token: $GITHUB_TOKEN
+    on:
+      branch: master
+      python: 3.6

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+# Include the readme file
+include README.rst
+include tox.ini
+
+recursive-include doc *.py
+recursive-include doc *.rst
+recursive-include doc Makefile
+recursive-include tests *.py
+recursive-include tests *.rst
+recursive-include tests *.txt
+
+exclude mlx/__version__.py
+
+recursive-exclude doc/_build *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,12 @@
 # Include the readme file
 include README.rst
 include tox.ini
+include .pylintrc
+include LICENCE
+include requirements.txt
 
+recursive-include *.yml
+recursive-include doc *.txt
 recursive-include doc *.py
 recursive-include doc *.rst
 recursive-include doc Makefile
@@ -12,3 +17,7 @@ recursive-include tests *.txt
 exclude mlx/__version__.py
 
 recursive-exclude doc/_build *
+
+# added by check_manifest.py
+include *.yml
+include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,19 +5,9 @@ include .pylintrc
 include LICENCE
 include requirements.txt
 
-recursive-include *.yml
-recursive-include doc *.txt
-recursive-include doc *.py
-recursive-include doc *.rst
-recursive-include doc Makefile
 recursive-include tests *.py
 recursive-include tests *.rst
 recursive-include tests *.txt
 
 exclude mlx/__version__.py
-
-recursive-exclude doc/_build *
-
-# added by check_manifest.py
-include *.yml
-include LICENSE
+exclude *.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@
 include README.rst
 include tox.ini
 include .pylintrc
-include LICENCE
+include LICENSE
 include requirements.txt
 
 recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# jira-traceability
-Sphinx plugin for creating Jira tickets based on traceable items

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,84 @@
+============
+Introduction
+============
+
+Sphinx plugin for creating Jira tickets based on traceable items that have been added by
+`mlx.traceability <https://pypi.org/project/mlx.traceability/>`_. You can look at this module as an extension for
+mlx.traceability.
+
+=====
+Usage
+=====
+
+--------------------
+Jira ticket creation
+--------------------
+
+Jira tickets that are based on traceable items can be automatically created by the plugin. A ticket gets created only
+for each item of which its ID **matches** the configured regular expression ``item_to_ticket_regex``.
+Duplication of tickets is avoided by querying Jira first for existing tickets based on the Jira project and the
+value of the ticket field configured by ``jira_field_id``. Below is an example configuration:
+
+Configuration
+=============
+
+.. code-block:: python
+
+    extensions = [
+        'mlx.traceability',
+        'mlx.jira_traceability',
+    ]
+
+    traceability_jira_automation = {
+        'api_endpoint': 'https://jira.atlassian.com/rest/api/latest/',
+        'username': 'my_username',
+        'password': 'my_password',
+        'item_to_ticket_regex': r'ACTION-12345_ACTION_\d+',
+        'jira_field_id': 'summary',
+        'issue_type': 'Task',
+        'project_key_regex': r'ACTION-(?P<project>\d{5})_',
+        'project_key_prefix': 'MLX',
+        'default_project': 'SWCC',
+        'relationship_to_parent': ('depends_on', r'MEETING-[\w_]+'),
+        'components': '[SW],[HW]',
+        'description_head': 'Action raised in meeting.\n\n',
+        'warn_if_exists': False,
+        'errors_to_warnings': True,
+        'notify_watchers': False,
+    }
+
+``project_key_regex`` can optionally be defined. This regular expression with a named group *project* is used to
+extract a certain part of the item ID to determine the Jira project key. ``project_key_prefix`` can optionally be
+defined to add a prefix to the match for ``project_key_regex``. Additionally, ``default_project`` defines the Jira
+project key or id in case the regular expression doesn't come up with a match or hasn't been configured.
+
+``item_to_ticket_regex`` defines the regular expression used to filter item IDs to be exported as Jira tickets.
+A warning gets reported when a Jira ticket already exists. These warnings can be disabled by setting
+``warn_if_exists`` to ``True``. Errors raised by Jira are converted to warnings by default. If you want these errors to
+crash your build, you can set ``errors_to_warnings`` to a falsy value.
+
+The item ID of a linked item can be added to the summary of the Jira ticket to create by specifying the relationship
+to this item in the value for setting ``relationship_to_parent``. The value can be a list or tuple with the relationship
+as the first element and the regular expression to match the linked item's ID as the second element.
+This feature makes it possible to create a query link in advance to list all Jira tickets that are related to this
+linked item.
+
+A string can be added to the start of a ticket's description by configuring ``description_head``. If the item to create
+a ticket for does not have a body, its caption will be used to build the ticket's description.
+
+Watchers of a ticket can be notified about the creation of the ticket by setting ``notify_watchers`` to ``True``.
+Note that this notification is only sent when the user to assign to the ticket is different from the default assignee
+configured in Jira.
+
+Attributes
+==========
+
+All attributes are optional and are defined in `the default configuration of mlx.traceability
+<https://melexis.github.io/sphinx-traceability-extension/configuration.html#default-config>`_.
+
+- *assignee* is used to assign a username to the Jira ticket.
+- *effort* is used to set the original effort estimation field. On failure, it gets appended to the description field.
+
+If the item for which to create a ticket has an item linked to it by a ``relationship_to_parent`` relationship,
+the *attendees* attribute of this linked item should be a comma-separated list of usernames that get added as watchers
+to the ticket.

--- a/mlx/__init__.py
+++ b/mlx/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+__import__('pkg_resources').declare_namespace(__name__)

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -1,0 +1,187 @@
+"""Functionality to interact with Jira"""
+from re import match, search
+
+from jira import JIRA, JIRAError
+from sphinx.util.logging import getLogger
+
+LOGGER = getLogger(__name__)
+
+
+def create_jira_issues(settings, traceability_collection):
+    """ Creates Jira issues using configuration variable ``traceability_jira_automation``.
+
+    Args:
+        settings (dict): Settings relevant to this feature
+        traceability_collection (TraceableCollection): Collection of all traceability items
+    """
+    mandatory_keys = ('api_endpoint', 'username', 'password', 'jira_field_id', 'item_to_ticket_regex', 'issue_type')
+    missing_keys = []
+    for key in mandatory_keys:
+        if not settings.get(key, None):
+            missing_keys.append(key)
+    if missing_keys:
+        return LOGGER.warning("Jira interaction failed: configuration is missing mandatory values for keys {}"
+                              .format(missing_keys))
+
+    issue_type = settings['issue_type']
+    general_fields = {}
+    general_fields['issuetype'] = {'name': issue_type}
+    components = []
+    for comp in settings.get('components', '').split(','):
+        if comp:
+            components.append({'name': comp.strip()})
+    if components:
+        general_fields['components'] = components
+
+    relevant_item_ids = traceability_collection.get_items(settings['item_to_ticket_regex'])
+    if relevant_item_ids:
+        jira = JIRA({"server": settings['api_endpoint']}, basic_auth=(settings['username'], settings['password']))
+        create_unique_issues(relevant_item_ids, jira, general_fields, settings, traceability_collection)
+
+
+def create_unique_issues(item_ids, jira, general_fields, settings, traceability_collection):
+    """ Creates a Jira ticket for each item matching the configured regex.
+
+    Duplication is avoided by first querying Jira issues filtering on project and summary.
+
+    Args:
+        item_ids (list): List of item IDs
+        jira (jira.JIRA): Jira interface object
+        general_fields (dict): Dictionary containing fields that are not item-specific
+        settings (dict): Configuration for this feature
+        traceability_collection (TraceableCollection): Collection of all traceability items
+    """
+    for item_id in item_ids:
+        fields = {}
+        item = traceability_collection.get_item(item_id)
+        project_id_or_key = determine_jira_project(settings.get('project_key_regex', ''),
+                                                   settings.get('project_key_prefix', ''),
+                                                   settings.get('default_project', ''),
+                                                   item_id)
+        if not project_id_or_key:
+            LOGGER.warning("Could not determine a JIRA project key or id for item {!r}".format(item_id))
+            continue
+
+        assignee = item.get_attribute('assignee')
+        attendees, jira_field = get_info_from_relationship(item, settings['relationship_to_parent'],
+                                                           traceability_collection)
+
+        jira_field_id = settings['jira_field_id']
+        matches = jira.search_issues("project={} and {} ~ {!r}".format(project_id_or_key,
+                                                                       jira_field_id,
+                                                                       jira_field))
+        if matches:
+            if settings.get('warn_if_exists', False):
+                LOGGER.warning("Won't create a {} for item {!r} because the Jira API query to check to prevent "
+                               "duplication returned {}".format(general_fields['issuetype']['name'], item_id, matches))
+            continue
+
+        fields['project'] = project_id_or_key
+        fields[jira_field_id] = jira_field
+        body = item.get_content()
+        if not body:
+            body = item.caption
+        fields['description'] = settings.get('description_head', '') + body
+        if assignee and not settings.get('notify_watchers', False):
+            fields['assignee'] = {'name': item.get_attribute('assignee')}
+            assignee = ''
+
+        issue = push_item_to_jira(jira, {**fields, **general_fields}, item, attendees, assignee)
+        print("mlx.jira-traceability: created Jira ticket for item {} here: {}".format(item_id, issue.permalink()))
+
+
+def push_item_to_jira(jira, fields, item, attendees, assignee):
+    """ Pushes the request to create a ticket on Jira for the given item.
+
+    The value of the effort option gets added to the Estimated field of the time tracking section. On failure, it gets
+    appended to the description instead.
+    The attendees are added to the watchers field. A warning is raised for each error returned by Jira.
+    The assignee can be set as the last step. When this results in a change in the ticket, the watchers get notified.
+
+    Args:
+        jira (jira.JIRA): Jira interface object
+        general_fields (dict): Dictionary containing all fields to include in the initial creation of the Jira ticket
+        item (TraceableItem): Traceable item to create the Jira ticket for
+        attendees (list): List of attendees that should get added to the watchers field
+        assignee (str): User to assign to the issue as a last and separate call to Jira; empty to skip this step
+
+    Returns:
+        jira.resources.Issue: newly created Jira issue
+    """
+    issue = jira.create_issue(**fields)
+
+    effort = item.get_attribute('effort')
+    if effort:
+        try:
+            issue.update(update={"timetracking": [{"edit": {"originalEstimate": effort}}]})
+        except JIRAError:
+            issue.update(description="{}\n\nEffort estimate: {}".format(item.get_content(), effort))
+
+    for attendee in attendees:
+        try:
+            jira.add_watcher(issue, attendee.strip())
+        except JIRAError as err:
+            LOGGER.warning("Jira interaction failed: item {}: error code {}: {}"
+                           .format(item.id, err.status_code, err.response.text))
+
+    if assignee:
+        jira.assign_issue(issue, assignee)
+    return issue
+
+
+def determine_jira_project(key_regex, key_prefix, default_project, item_id):
+    """ Determines the JIRA project key or id to use for give item ID.
+
+    Args:
+        key_regex (str): Regular expression used to scan through the <<item_id>>. In case of a hit, the capture group
+            with name 'project' will be used to build the project key.
+        key_prefix (str): Prefix to use if <<key_regex>> gets used to build the project key.
+        default_project (str): Project key or id to use if a match for <<key_regex>> doesn't get used.
+
+    Returns:
+        str: JIRA project key or id.
+    """
+    key_match = search(key_regex, item_id)
+    try:
+        return key_prefix + key_match.group('project')
+    except (AttributeError, IndexError):
+        return default_project
+
+
+def get_info_from_relationship(item, config_for_parent, traceability_collection):
+    """ Gets info from the first item with the given relationship.
+
+    Its id is added to the jira field and if it has the 'attendees' attribute, its value is returned as a list.
+
+    Args:
+        item (TraceableItem): Traceable item to create the Jira ticket for
+        config_for_parent (str/tuple/list): Relationship to the item to extract info from / tuple or list with
+            relationship as the first element and regex to match ID of parent item as the second element
+        traceability_collection (TraceableCollection): Collection of all traceability items
+
+    Returns:
+        list: List of attendees (str)
+        str: Contents for field with id jira_field_id
+    """
+    attendees = []
+    jira_field = item.caption
+    if config_for_parent:
+        if isinstance(config_for_parent, (tuple, list)):
+            relationship = config_for_parent[0]
+            parent_regex = config_for_parent[1]
+        else:
+            relationship = config_for_parent
+            parent_regex = '.+'
+        parent_ids = item.iter_targets(relationship)
+        parent_id = None
+        for id_ in parent_ids:
+            if match(parent_regex, id_):
+                parent_id = id_
+                break
+        if parent_id:
+            parent = traceability_collection.get_item(parent_id)
+            jira_field = "{id}: {field}".format(id=parent_id, field=jira_field)  # prepend item ID of parent
+            attr_value = parent.get_attribute('attendees')
+            if attr_value:
+                attendees = attr_value.split(',')
+    return attendees, jira_field

--- a/mlx/jira_traceability.py
+++ b/mlx/jira_traceability.py
@@ -1,0 +1,35 @@
+from sphinx.util.logging import getLogger
+
+from .jira_interaction import create_jira_issues
+
+LOGGER = getLogger(__name__)
+
+
+def jira_interaction(app):
+    """ Execute the functionality that creates Jira tickets based on traceable items.
+
+    Args:
+        app: Sphinx application object to use.
+    """
+    try:
+        create_jira_issues(app.config.traceability_jira_automation, app.builder.env.traceability_collection)
+    except Exception as err:  # pylint: disable=broad-except
+        if app.config.traceability_jira_automation.get('errors_to_warnings', True):
+            LOGGER.warning("Jira interaction failed: {}".format(err))
+        else:
+            raise err
+
+
+def perform_consistency_check(app, doctree):
+    """Consistency checker callback"""
+    if app.config.traceability_jira_automation:
+        jira_interaction(app)
+
+
+# -----------------------------------------------------------------------------
+# Extension setup
+def setup(app):
+    # Configuration for automated issue creation in JIRA
+    app.add_config_value('traceability_jira_automation', {}, 'env')
+
+    app.connect('env-check-consistency', perform_consistency_check)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements file is made purely for GitHub to track dependencies. It should be automatically taken from setup.py
+.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+description-file = README.rst
+
+[bdist_wheel]
+universal=1
+
+[tool:pytest]
+norecursedirs= .tox
+
+[flake8]
+exclude = .git,*conf.py,build,dist
+max-line-length = 120
+
+[check-manifest]
+ignore=
+    *.yml

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+project_url = 'https://github.com/melexis/jira-traceability'
+
+requires = ['Sphinx>=2.1', 'jira', 'mlx.traceability>=6.0.0']
+
+setup(
+    name='mlx.jira-traceability',
+    use_scm_version={
+        'write_to': 'mlx/__version__.py'
+    },
+    setup_requires=['setuptools_scm'],
+    url=project_url,
+    license='Apache License, Version 2.0',
+    author='Jasper Craeghs',
+    author_email='jce@melexis.com',
+    description='Sphinx plugin to create Jira tickets based on traceable items',
+    long_description=open("README.rst").read(),
+    long_description_content_type='text/x-rst',
+    zip_safe=False,
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Framework :: Sphinx :: Extension',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Topic :: Automation',
+        'Topic :: Documentation',
+        'Topic :: Utilities',
+    ],
+    platforms='any',
+    packages=find_packages(exclude=['tests', 'doc']),
+    include_package_data=True,
+    install_requires=requires,
+    namespace_packages=['mlx'],
+    keywords=[
+        'traceability',
+        'jira',
+        'sphinx',
+    ],
+)

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -1,0 +1,370 @@
+from collections import namedtuple
+from logging import WARNING, warning
+from unittest import TestCase, mock
+
+from jira import JIRAError
+
+from mlx.traceable_attribute import TraceableAttribute
+from mlx.traceable_collection import TraceableCollection
+from mlx.traceable_item import TraceableItem
+import mlx.jira_interaction as dut
+
+
+@mock.patch('mlx.jira_interaction.JIRA')
+class TestJiraInteraction(TestCase):
+    def setUp(self):
+        self.general_fields = {
+            'components': [
+                {'name': '[SW]'},
+                {'name': '[HW]'},
+            ],
+            'issuetype': {'name': 'Task'},
+            'project': 'MLX12345',
+        }
+        self.settings = {
+            'api_endpoint': 'https://jira.atlassian.com/rest/api/latest/',
+            'username': 'my_username',
+            'password': 'my_password',
+            'jira_field_id': 'summary',
+            'issue_type': 'Task',
+            'item_to_ticket_regex': r'ACTION-12345_ACTION_\d+',
+            'project_key_regex': r'ACTION-(?P<project>\d{5})_',
+            'project_key_prefix': 'MLX',
+            'default_project': 'SWCC',
+            'warn_if_exists': True,
+            'relationship_to_parent': 'depends_on',
+            'components': '[SW],[HW]',
+            'catch_errors': False,
+            'notify_watchers': False,
+        }
+        self.coll = TraceableCollection()
+        parent = TraceableItem('MEETING-12345_2')
+        action1 = TraceableItem('ACTION-12345_ACTION_1')
+        action1.caption = 'Caption for action 1'
+        action1.set_content('Description for action 1')
+        action2 = TraceableItem('ACTION-12345_ACTION_2')
+        action2.caption = 'Caption for action 2'
+        action2.set_content('')
+        action3 = TraceableItem('ACTION-98765_ACTION_55')
+        item1 = TraceableItem('ITEM-12345_1')
+
+        effort_attr = TraceableAttribute('effort', r'^([\d\.]+(mo|[wdhm]) ?)+$')
+        assignee_attr = TraceableAttribute('assignee', '^.*$')
+        attendees_attr = TraceableAttribute('attendees', '^([A-Z]{3}[, ]*)+$')
+        TraceableItem.define_attribute(effort_attr)
+        TraceableItem.define_attribute(assignee_attr)
+        TraceableItem.define_attribute(attendees_attr)
+
+        parent.add_attribute('attendees', 'ABC, ZZZ')
+        action1.add_attribute('effort', '2w 3d 4h 55m')
+        action1.add_attribute('assignee', 'ABC')
+        action2.add_attribute('assignee', 'ZZZ')
+        action3.add_attribute('assignee', 'ABC')
+
+        for item in (parent, action1, action2, action3, item1):
+            self.coll.add_item(item)
+
+        self.coll.add_relation_pair('depends_on', 'impacts_on')
+        self.coll.add_relation(action1.id, 'impacts_on', item1.id)  # to be ignored
+        self.coll.add_relation(action1.id, 'depends_on', parent.id)  # to be taken into account
+        self.coll.add_relation(action2.id, 'impacts_on', parent.id)  # to be ignored
+
+    def test_missing_endpoint(self, *_):
+        self.settings.pop('api_endpoint')
+        with self.assertLogs(level=WARNING) as cm:
+            dut.create_jira_issues(self.settings, None)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:sphinx.mlx.jira_interaction:Jira interaction failed: configuration is "
+             "missing mandatory values for keys ['api_endpoint']"]
+        )
+
+    def test_missing_username(self, *_):
+        self.settings.pop('username')
+        with self.assertLogs(level=WARNING) as cm:
+            dut.create_jira_issues(self.settings, None)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:sphinx.mlx.jira_interaction:Jira interaction failed: configuration is "
+             "missing mandatory values for keys ['username']"]
+        )
+
+    def test_missing_all_mandatory(self, *_):
+        mandatory_keys = ['api_endpoint', 'username', 'password', 'item_to_ticket_regex', 'issue_type']
+        for key in mandatory_keys:
+            self.settings.pop(key)
+        with self.assertLogs(level=WARNING) as cm:
+            dut.create_jira_issues(self.settings, None)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:sphinx.mlx.jira_interaction:Jira interaction failed: configuration is "
+             "missing mandatory values for keys {}".format(mandatory_keys)]
+        )
+
+    def test_missing_all_optional_one_mandatory(self, *_):
+        keys_to_remove = ['components', 'project_key_prefix', 'project_key_regex', 'default_project',
+                          'relationship_to_parent', 'warn_if_exists', 'catch_errors', 'password']
+        for key in keys_to_remove:
+            self.settings.pop(key)
+        with self.assertLogs(level=WARNING) as cm:
+            dut.create_jira_issues(self.settings, None)
+        self.assertEqual(
+            cm.output,
+            ["WARNING:sphinx.mlx.jira_interaction:Jira interaction failed: configuration is "
+             "missing mandatory values for keys ['password']"]
+        )
+
+    def test_create_jira_issues_unique(self, jira):
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = []
+        with self.assertLogs(level=WARNING) as cm:
+            warning('Dummy log')
+            dut.create_jira_issues(self.settings, self.coll)
+
+        self.assertEqual(
+            cm.output,
+            ['WARNING:root:Dummy log']
+        )
+
+        self.assertEqual(jira.call_args,
+                         mock.call({'server': 'https://jira.atlassian.com/rest/api/latest/'},
+                                   basic_auth=('my_username', 'my_password')))
+        self.assertEqual(jira_mock.search_issues.call_args_list,
+                         [
+                             mock.call("project=MLX12345 and summary ~ 'MEETING-12345_2: Caption for action 1'"),
+                             mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
+                         ])
+
+        issue = jira_mock.create_issue.return_value
+        self.assertEqual(
+            jira_mock.create_issue.call_args_list,
+            [
+                mock.call(
+                    summary='MEETING-12345_2: Caption for action 1',
+                    description='Description for action 1',
+                    assignee={'name': 'ABC'},
+                    **self.general_fields
+                ),
+                mock.call(
+                    summary='Caption for action 2',
+                    description='Caption for action 2',
+                    assignee={'name': 'ZZZ'},
+                    **self.general_fields
+                ),
+            ])
+
+        self.assertEqual(
+            issue.update.call_args_list,
+            [mock.call(update={'timetracking': [{"edit": {"originalEstimate": '2w 3d 4h 55m'}}]})]
+        )
+
+        # attendees added for action1 since it is linked with depends_on to parent item with ``attendees`` attribute
+        self.assertEqual(jira_mock.add_watcher.call_args_list,
+                         [
+                             mock.call(issue, 'ABC'),
+                             mock.call(issue, 'ZZZ'),
+                         ])
+
+        self.assertEqual(jira_mock.assign_issue.call_args_list, [])
+
+    def test_notify_watchers(self, jira):
+        """ Test effect of setting `notify_watchers` to True
+
+        By default, watchers are added as the last step. When setting `notify_watchers` is set to a truthy value,
+        the assignee should be set in an additional call to Jira after the watchers have been added.
+        """
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = []
+        self.settings['notify_watchers'] = True
+
+        with self.assertLogs(level=WARNING):
+            warning('Dummy log')
+            dut.create_jira_issues(self.settings, self.coll)
+
+        # No kwarg 'assignee' should be passed
+        self.assertEqual(
+            jira_mock.create_issue.call_args_list,
+            [
+                mock.call(
+                    description='Description for action 1',
+                    summary='MEETING-12345_2: Caption for action 1',
+                    **self.general_fields
+                ),
+                mock.call(
+                    description='Caption for action 2',
+                    summary='Caption for action 2',
+                    **self.general_fields
+                ),
+            ])
+        # Additional call to set assignee should be made after the issue has been created
+        issue = jira_mock.create_issue.return_value
+        self.assertEqual(jira_mock.assign_issue.call_args_list,
+                         [
+                             mock.call(issue, 'ABC'),
+                             mock.call(issue, 'ZZZ'),
+                         ])
+
+    def test_create_issue_timetracking_unavailable(self, jira):
+        """ Value of effort attribute should be appended to description when setting timetracking field raises error """
+        def jira_update_mock(update={}, **_):
+            if 'timetracking' in update:
+                raise JIRAError
+
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = []
+        issue = jira_mock.create_issue.return_value
+        issue.update.side_effect = jira_update_mock
+        dut.create_jira_issues(self.settings, self.coll)
+
+        self.assertEqual(
+            issue.update.call_args_list,
+            [
+                mock.call(update={'timetracking': [{"edit": {"originalEstimate": '2w 3d 4h 55m'}}]}),
+                mock.call(description="Description for action 1\n\nEffort estimate: 2w 3d 4h 55m"),
+            ]
+        )
+
+    def test_prevent_duplication(self, jira):
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = ['Jira already contains this ticket']
+        with self.assertLogs(level=WARNING) as cm:
+            dut.create_jira_issues(self.settings, self.coll)
+
+        self.assertEqual(
+            cm.output,
+            ["WARNING:sphinx.mlx.jira_interaction:Won't create a Task for item "
+             "'ACTION-12345_ACTION_1' because the Jira API query to check to prevent "
+             "duplication returned ['Jira already contains this ticket']",
+             "WARNING:sphinx.mlx.jira_interaction:Won't create a Task for item "
+             "'ACTION-12345_ACTION_2' because the Jira API query to check to prevent "
+             "duplication returned ['Jira already contains this ticket']"]
+        )
+
+    def test_no_warning_about_duplication(self, jira):
+        """ Default behavior should be no warning when a Jira ticket doesn't get created to prevent duplication """
+        self.settings.pop('warn_if_exists')
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = ['Jira already contains this ticket']
+        with self.assertLogs(level=WARNING) as cm:
+            warning('Dummy log')
+            dut.create_jira_issues(self.settings, self.coll)
+
+        self.assertEqual(
+            cm.output,
+            ['WARNING:root:Dummy log']
+        )
+
+    def test_default_project(self, jira):
+        """ The default_project should get used when project_key_regex doesn't match """
+        self.settings['project_key_regex'] = 'regex_that_does_not_match_any_id'
+        self.general_fields['project'] = self.settings['default_project']
+
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = []
+        dut.create_jira_issues(self.settings, self.coll)
+
+        self.assertEqual(
+            jira_mock.create_issue.call_args_list,
+            [
+                mock.call(
+                    summary='MEETING-12345_2: Caption for action 1',
+                    description='Description for action 1',
+                    assignee={'name': 'ABC'},
+                    **self.general_fields
+                ),
+                mock.call(
+                    summary='Caption for action 2',
+                    description='Caption for action 2',
+                    assignee={'name': 'ZZZ'},
+                    **self.general_fields
+                ),
+            ])
+
+    def test_add_watcher_jira_error(self, jira):
+        Response = namedtuple('Response', 'text')
+
+        def jira_add_watcher_mock(*_):
+            raise JIRAError(status_code=401, response=Response('dummy msg'))
+
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = []
+        jira_mock.add_watcher.side_effect = jira_add_watcher_mock
+        with self.assertLogs(level=WARNING) as cm:
+            dut.create_jira_issues(self.settings, self.coll)
+
+        error_msg = ("WARNING:sphinx.mlx.jira_interaction:Jira interaction failed: item ACTION-12345_ACTION_1: "
+                     "error code 401: dummy msg")
+        self.assertEqual(
+            cm.output,
+            [error_msg, error_msg]
+        )
+
+    def test_tuple_for_relationship_to_parent(self, jira):
+        """
+        Tests that the linked item, added in this test case, is selected by configured tuple for
+        ``relationship_to_parent``
+        """
+        self.settings['relationship_to_parent'] = ('depends_on', r'ZZZ-[\w_]+')
+        alternative_parent = TraceableItem('ZZZ-TO_BE_PRIORITIZED')
+        # to be prioritized over MEETING-12345_2
+        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)
+
+        jira_mock = jira.return_value
+        jira_mock.search_issues.return_value = []
+        with self.assertLogs(level=WARNING) as cm:
+            warning('Dummy log')
+            dut.create_jira_issues(self.settings, self.coll)
+
+        self.assertEqual(
+            cm.output,
+            ['WARNING:root:Dummy log']
+        )
+
+        self.assertEqual(jira_mock.search_issues.call_args_list,
+                         [
+                             mock.call("project=MLX12345 and summary ~ 'ZZZ-TO_BE_PRIORITIZED: Caption for action 1'"),
+                             mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
+                         ])
+
+        self.assertEqual(
+            jira_mock.create_issue.call_args_list,
+            [
+                mock.call(
+                    summary='ZZZ-TO_BE_PRIORITIZED: Caption for action 1',
+                    description='Description for action 1',
+                    assignee={'name': 'ABC'},
+                    **self.general_fields
+                ),
+                mock.call(
+                    summary='Caption for action 2',
+                    description='Caption for action 2',
+                    assignee={'name': 'ZZZ'},
+                    **self.general_fields
+                ),
+            ])
+
+    def test_get_info_from_relationship_tuple(self, _):
+        """ Tests dut.get_info_from_relationship with a config_for_parent parameter as tuple """
+        relationship_to_parent = ('depends_on', r'ZZZ-[\w_]+')
+        alternative_parent = TraceableItem('ZZZ-TO_BE_PRIORITIZED')
+        # to be prioritized over MEETING-12345_2
+        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)
+        action1 = self.coll.get_item('ACTION-12345_ACTION_1')
+
+        attendees, jira_field = dut.get_info_from_relationship(action1, relationship_to_parent, self.coll)
+
+        self.assertEqual(attendees, [])
+        self.assertEqual(jira_field, 'ZZZ-TO_BE_PRIORITIZED: Caption for action 1')
+
+    def test_get_info_from_relationship_str(self, _):
+        """ Tests dut.get_info_from_relationship with a config_for_parent parameter as str """
+        relationship_to_parent = 'depends_on'
+        alternative_parent = TraceableItem('ZZZ-TO_BE_IGNORED')
+        # not to be prioritized over MEETING-12345_2 (natural sorting)
+        self.coll.add_relation('ACTION-12345_ACTION_1', 'depends_on', alternative_parent.id)
+        action1 = self.coll.get_item('ACTION-12345_ACTION_1')
+
+        attendees, jira_field = dut.get_info_from_relationship(action1, relationship_to_parent, self.coll)
+
+        self.assertEqual(attendees, ['ABC', ' ZZZ'])
+        self.assertEqual(jira_field, 'MEETING-12345_2: Caption for action 1')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,99 @@
+[tox]
+envlist =
+    clean,
+    check,
+    {py37},
+    {sphinx2.1,sphinx-latest},
+
+[testenv]
+basepython =
+    pypy: {env:TOXPYTHON:pypy}
+    py35: {env:TOXPYTHON:python3.5}
+    py36: {env:TOXPYTHON:python3.6}
+    py37: {env:TOXPYTHON:python3.7}
+    py38: {env:TOXPYTHON:python3.8}
+    {clean,check,report,coveralls,codecov}: python3
+    {sphinx2.1,sphinx-latest}: python3
+setenv =
+    PYTHONPATH={toxinidir}/tests
+    PYTHONUNBUFFERED=yes
+passenv =
+    *
+usedevelop = true
+deps=
+    mock
+    pytest
+    pytest-cov
+    coverage
+    reportlab
+    sphinx_rtd_theme==0.5.0
+    parameterized
+commands=
+    {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}
+
+[testenv:check]
+deps =
+    docutils
+    twine
+    check-manifest
+    flake8
+skip_install = true
+commands =
+    python setup.py sdist
+    twine check dist/*
+    check-manifest {toxinidir} -u
+    flake8 mlx tests setup.py
+
+[testenv:sphinx2.1]
+deps=
+    {[testenv]deps}
+    sphinx <= 2.1.9999
+    sphinxcontrib-plantuml
+    mlx.warnings >= 1.2.0
+whitelist_externals =
+    make
+    tee
+    mlx-warnings
+commands=
+    mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 --command make -C doc html
+
+[testenv:sphinx-latest]
+deps=
+    {[testenv]deps}
+    sphinx
+    sphinxcontrib-plantuml
+    mlx.warnings >= 1.2.0
+whitelist_externals =
+    make
+    tee
+    mlx-warnings
+commands=
+    mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 --command make -C doc html
+
+[testenv:coveralls]
+deps =
+    coveralls
+skip_install = true
+commands =
+    coveralls []
+
+[testenv:codecov]
+deps =
+    codecov
+skip_install = true
+commands =
+    coverage xml --ignore-errors
+    codecov
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage combine --append
+    coverage report
+    coverage html
+
+[testenv:clean]
+commands = coverage erase
+skip_install = true
+deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist =
     clean,
     check,
     {py37},
-    {sphinx2.1,sphinx-latest},
 
 [testenv]
 basepython =
@@ -13,13 +12,12 @@ basepython =
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     {clean,check,report,coveralls,codecov}: python3
-    {sphinx2.1,sphinx-latest}: python3
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
 passenv =
     *
-usedevelop = true
+usedevelop = false
 deps=
     mock
     pytest
@@ -43,32 +41,6 @@ commands =
     twine check dist/*
     check-manifest {toxinidir} -u
     flake8 mlx tests setup.py
-
-[testenv:sphinx2.1]
-deps=
-    {[testenv]deps}
-    sphinx <= 2.1.9999
-    sphinxcontrib-plantuml
-    mlx.warnings >= 1.2.0
-whitelist_externals =
-    make
-    tee
-    mlx-warnings
-commands=
-    mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 --command make -C doc html
-
-[testenv:sphinx-latest]
-deps=
-    {[testenv]deps}
-    sphinx
-    sphinxcontrib-plantuml
-    mlx.warnings >= 1.2.0
-whitelist_externals =
-    make
-    tee
-    mlx-warnings
-commands=
-    mlx-warnings --sphinx --maxwarnings 0 --minwarnings 0 --command make -C doc html
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
Removed from mlx.traceability in [this PR](https://github.com/melexis/sphinx-traceability-extension/pull/184) and moved here so that it can live as a separate Sphinx plugin, to be added to `extensions` list in `conf.py` after `'mlx.traceability'` as `'mlx.jira_traceability'`. The functionality remains identical besides the following fix:

- Removed explicit flag `notifyUsers=False` in the query to Jira API because it can cause permission error.