### PR TITLE
Escape special characters in string for JQL query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
   - lsb_release -a
 
 install:
-  - pip install --upgrade pip
   - pip install tox
   - pip install coverage
   - virtualenv --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - lsb_release -a
 
 install:
+  - pip install --upgrade pip
   - pip install tox
   - pip install coverage
   - virtualenv --version

--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -67,9 +67,10 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
                                                            traceability_collection)
 
         jira_field_id = settings['jira_field_id']
-        matches = jira.search_issues("project={} and {} ~ {!r}".format(project_id_or_key,
+        jira_field_query_value = escape_special_characters(jira_field)
+        matches = jira.search_issues("project={} and {} ~ '{}'".format(project_id_or_key,
                                                                        jira_field_id,
-                                                                       jira_field))
+                                                                       jira_field_query_value))
         if matches:
             if settings.get('warn_if_exists', False):
                 LOGGER.warning("Won't create a {} for item {!r} because the Jira API query to check to prevent "
@@ -191,3 +192,21 @@ def get_info_from_relationship(item, config_for_parent, traceability_collection)
             if attr_value:
                 attendees = attr_value.split(',')
     return attendees, jira_field
+
+
+def escape_special_characters(input_string):
+    """ Escape special characters to avoid unwanted behavior.
+
+    Note that they are not stored in the index so you cannot search for them.
+
+    Args:
+        input_string (str): String to escape special characters of
+
+    Returns:
+        str: Input string that has its special characters escaped
+    """
+    prepared_string = input_string
+    for special_char in ("\\", "+", "-", "&", "|", "!", "(", ")", "{", "}", "[", "]", "^", "~", "*", "?", ":"):
+        if special_char in prepared_string:
+            prepared_string = prepared_string.replace(special_char, "\\" + special_char)
+    return prepared_string

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -322,7 +322,8 @@ class TestJiraInteraction(TestCase):
 
         self.assertEqual(jira_mock.search_issues.call_args_list,
                          [
-                             mock.call("project=MLX12345 and summary ~ 'ZZZ\\-TO_BE_PRIORITIZED\\: Caption for action 1\\?'"),
+                             mock.call("project=MLX12345 and summary ~ "
+                                       "'ZZZ\\-TO_BE_PRIORITIZED\\: Caption for action 1\\?'"),
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -40,7 +40,7 @@ class TestJiraInteraction(TestCase):
         self.coll = TraceableCollection()
         parent = TraceableItem('MEETING-12345_2')
         action1 = TraceableItem('ACTION-12345_ACTION_1')
-        action1.caption = 'Caption for action 1'
+        action1.caption = 'Caption for action 1?'
         action1.set_content('Description for action 1')
         action2 = TraceableItem('ACTION-12345_ACTION_2')
         action2.caption = 'Caption for action 2'
@@ -131,7 +131,7 @@ class TestJiraInteraction(TestCase):
                                    basic_auth=('my_username', 'my_password')))
         self.assertEqual(jira_mock.search_issues.call_args_list,
                          [
-                             mock.call("project=MLX12345 and summary ~ 'MEETING-12345_2: Caption for action 1'"),
+                             mock.call("project=MLX12345 and summary ~ 'MEETING\\-12345_2\\: Caption for action 1\\?'"),
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 
@@ -140,7 +140,7 @@ class TestJiraInteraction(TestCase):
             jira_mock.create_issue.call_args_list,
             [
                 mock.call(
-                    summary='MEETING-12345_2: Caption for action 1',
+                    summary='MEETING-12345_2: Caption for action 1?',
                     description='Description for action 1',
                     assignee={'name': 'ABC'},
                     **self.general_fields
@@ -187,7 +187,7 @@ class TestJiraInteraction(TestCase):
             [
                 mock.call(
                     description='Description for action 1',
-                    summary='MEETING-12345_2: Caption for action 1',
+                    summary='MEETING-12345_2: Caption for action 1?',
                     **self.general_fields
                 ),
                 mock.call(
@@ -267,7 +267,7 @@ class TestJiraInteraction(TestCase):
             jira_mock.create_issue.call_args_list,
             [
                 mock.call(
-                    summary='MEETING-12345_2: Caption for action 1',
+                    summary='MEETING-12345_2: Caption for action 1?',
                     description='Description for action 1',
                     assignee={'name': 'ABC'},
                     **self.general_fields
@@ -322,7 +322,7 @@ class TestJiraInteraction(TestCase):
 
         self.assertEqual(jira_mock.search_issues.call_args_list,
                          [
-                             mock.call("project=MLX12345 and summary ~ 'ZZZ-TO_BE_PRIORITIZED: Caption for action 1'"),
+                             mock.call("project=MLX12345 and summary ~ 'ZZZ\\-TO_BE_PRIORITIZED\\: Caption for action 1\\?'"),
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 
@@ -330,7 +330,7 @@ class TestJiraInteraction(TestCase):
             jira_mock.create_issue.call_args_list,
             [
                 mock.call(
-                    summary='ZZZ-TO_BE_PRIORITIZED: Caption for action 1',
+                    summary='ZZZ-TO_BE_PRIORITIZED: Caption for action 1?',
                     description='Description for action 1',
                     assignee={'name': 'ABC'},
                     **self.general_fields
@@ -354,7 +354,7 @@ class TestJiraInteraction(TestCase):
         attendees, jira_field = dut.get_info_from_relationship(action1, relationship_to_parent, self.coll)
 
         self.assertEqual(attendees, [])
-        self.assertEqual(jira_field, 'ZZZ-TO_BE_PRIORITIZED: Caption for action 1')
+        self.assertEqual(jira_field, 'ZZZ-TO_BE_PRIORITIZED: Caption for action 1?')
 
     def test_get_info_from_relationship_str(self, _):
         """ Tests dut.get_info_from_relationship with a config_for_parent parameter as str """
@@ -367,4 +367,4 @@ class TestJiraInteraction(TestCase):
         attendees, jira_field = dut.get_info_from_relationship(action1, relationship_to_parent, self.coll)
 
         self.assertEqual(attendees, ['ABC', ' ZZZ'])
-        self.assertEqual(jira_field, 'MEETING-12345_2: Caption for action 1')
+        self.assertEqual(jira_field, 'MEETING-12345_2: Caption for action 1?')

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps=
     sphinx_rtd_theme==0.5.0
     parameterized
 commands=
+    pip install --upgrade pip
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}
 
 [testenv:check]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist =
     clean,
     check,
     {py37},
+requires =
+    pip>=20.3.4
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ deps=
     sphinx_rtd_theme==0.5.0
     parameterized
 commands=
-    pip install --upgrade pip
     {posargs:py.test --cov=mlx --cov-report=term-missing -vv tests/}
 
 [testenv:check]


### PR DESCRIPTION
Escape special characters in string for JQL query to avoid unwanted behavior that these characters may trigger.

For example, the special character `?` gets treated as a [single character wildcard](https://confluence.atlassian.com/jiracoreserver073/search-syntax-for-text-fields-861257223.html#Searchsyntaxfortextfields-wildcardsWildcardsearches:?and*) in the JQL query used by the plugin and should be escaped to avoid duplication of JIRA tickets.

`project = example AND summary ~ 'Example caption?'`

becomes 

`project = example AND summary ~ 'Example caption\\?'`

Bug reported by @kravchenkoloznia.