### PR TITLE
Fix JQL query with a special character

### DIFF
--- a/mlx/jira_interaction.py
+++ b/mlx/jira_interaction.py
@@ -208,5 +208,5 @@ def escape_special_characters(input_string):
     prepared_string = input_string
     for special_char in ("\\", "+", "-", "&", "|", "!", "(", ")", "{", "}", "[", "]", "^", "~", "*", "?", ":"):
         if special_char in prepared_string:
-            prepared_string = prepared_string.replace(special_char, "\\" + special_char)
+            prepared_string = prepared_string.replace(special_char, r"\\" + special_char)
     return prepared_string

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -131,7 +131,7 @@ class TestJiraInteraction(TestCase):
                                    basic_auth=('my_username', 'my_password')))
         self.assertEqual(jira_mock.search_issues.call_args_list,
                          [
-                             mock.call("project=MLX12345 and summary ~ 'MEETING\\-12345_2\\: Caption for action 1\\?'"),
+                             mock.call("project=MLX12345 and summary ~ 'MEETING\\\\-12345_2\\\\: Caption for action 1\\\\?'"),
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 
@@ -323,7 +323,7 @@ class TestJiraInteraction(TestCase):
         self.assertEqual(jira_mock.search_issues.call_args_list,
                          [
                              mock.call("project=MLX12345 and summary ~ "
-                                       "'ZZZ\\-TO_BE_PRIORITIZED\\: Caption for action 1\\?'"),
+                                       "'ZZZ\\\\-TO_BE_PRIORITIZED\\\\: Caption for action 1\\\\?'"),
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -131,7 +131,8 @@ class TestJiraInteraction(TestCase):
                                    basic_auth=('my_username', 'my_password')))
         self.assertEqual(jira_mock.search_issues.call_args_list,
                          [
-                             mock.call("project=MLX12345 and summary ~ 'MEETING\\\\-12345_2\\\\: Caption for action 1\\\\?'"),
+                             mock.call(
+                                 "project=MLX12345 and summary ~ 'MEETING\\\\-12345_2\\\\: Caption for action 1\\\\?'"),
                              mock.call("project=MLX12345 and summary ~ 'Caption for action 2'"),
                          ])
 


### PR DESCRIPTION
Use two instead of one backslash to escape special characters in JQL query.

This bugfix resolves the following error: `Error in the JQL Query: '\\:' is an illegal JQL escape sequence. The valid escape sequences are \\', \\\", \\t, \\n, \\r, \\\\, '\\ ' and \\uXXXX.`