### PR TITLE
Validate the configured Jira components

### DIFF
--- a/mlx/jira_traceability/jira_interaction.py
+++ b/mlx/jira_traceability/jira_interaction.py
@@ -56,6 +56,9 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
         settings (dict): Configuration for this feature
         traceability_collection (TraceableCollection): Collection of all traceability items
     """
+    # Cache for validated components per project to avoid repeated validation
+    validated_components_cache = {}
+
     for item_id in item_ids:
         fields = {}
         item = traceability_collection.get_item(item_id)
@@ -103,12 +106,18 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
             fields['assignee'] = {'name': assignee}
             assignee = ''
 
-        # Validate components against Jira project
-        if 'components' in general_fields:
-            general_fields['components'] = validate_components(jira, project_id_or_key,
-                                                               general_fields['components'])
+        # Validate components against Jira project (cached per project)
+        project_general_fields = general_fields.copy()
+        if 'components' in project_general_fields:
+            if project_id_or_key not in validated_components_cache:
+                # Validate components for this project and cache the result
+                validated_components_cache[project_id_or_key] = validate_components(
+                    jira, project_id_or_key, project_general_fields['components']
+                )
+            # Use cached validated components
+            project_general_fields['components'] = validated_components_cache[project_id_or_key]
 
-        issue = push_item_to_jira(jira, {**fields, **general_fields}, item, attendees, assignee)
+        issue = push_item_to_jira(jira, {**fields, **project_general_fields}, item, attendees, assignee)
         print("mlx.jira-traceability: created Jira ticket for item {} here: {}".format(item_id, issue.permalink()))
 
 

--- a/mlx/jira_traceability/jira_interaction.py
+++ b/mlx/jira_traceability/jira_interaction.py
@@ -3,7 +3,7 @@ from re import match, search
 
 from jira import JIRA, JIRAError
 from sphinx.util.logging import getLogger
-from .jira_utils import format_jira_error
+from .jira_utils import format_jira_error, validate_components
 
 LOGGER = getLogger('mlx.jira_traceability')
 
@@ -102,6 +102,11 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
         if assignee and not settings.get('notify_watchers', False):
             fields['assignee'] = {'name': assignee}
             assignee = ''
+
+        # Validate components against Jira project
+        if 'components' in general_fields:
+            general_fields['components'] = validate_components(jira, project_id_or_key,
+                                                               general_fields['components'])
 
         issue = push_item_to_jira(jira, {**fields, **general_fields}, item, attendees, assignee)
         print("mlx.jira-traceability: created Jira ticket for item {} here: {}".format(item_id, issue.permalink()))

--- a/mlx/jira_traceability/jira_utils.py
+++ b/mlx/jira_traceability/jira_utils.py
@@ -1,6 +1,9 @@
 """Utility functions for JIRA error handling and formatting"""
 
-from jira.exceptions import JIRAError
+from jira import JIRAError
+from sphinx.util.logging import getLogger
+
+LOGGER = getLogger('mlx.jira_traceability')
 
 
 def format_jira_error(err):
@@ -25,3 +28,41 @@ def format_jira_error(err):
             return f"JIRA error: {str(err)}"
     else:
         return f"Error: {str(err)}"
+
+
+def validate_components(jira, project_id_or_key, components):
+    """Validate a list of components against a Jira project's available components.
+
+    Attempts to use original component names first, falling back to stripped versions (removing '[' and ']').
+
+    Args:
+        jira: Jira interface object
+        project_id_or_key (str): Project key or ID to validate components against
+        components (list): List of component dictionaries with 'name' key
+
+    Returns:
+        list: List of valid component dictionaries, using stripped names where applicable
+    """
+    try:
+        valid_components = jira.project_components(project_id_or_key)
+        valid_component_names = [c.name for c in valid_components]
+        invalid_components = []
+        final_components = []
+        for comp in components:
+            comp_name = comp['name']
+            if comp_name in valid_component_names:
+                final_components.append({'name': comp_name})
+            else:
+                stripped_name = comp_name.strip('[]')
+                if stripped_name != comp_name and stripped_name in valid_component_names:
+                    final_components.append({'name': stripped_name})
+                    LOGGER.info(f"Using stripped component name '{stripped_name}' instead of "
+                                f"'{comp_name}' for project {project_id_or_key}")
+                else:
+                    invalid_components.append(comp_name)
+        if invalid_components:
+            LOGGER.warning(f"Invalid components found for project {project_id_or_key}: {', '.join(invalid_components)}")
+        return final_components
+    except JIRAError as err:
+        LOGGER.warning(f"Failed to validate components: {err.text}")
+        return components  # Return original components if validation fails


### PR DESCRIPTION
Our old Jira projects had the component `[SW]` available. New Jira projects use `SW`. We use the same configuration in our `conf.py` for new and old Jira projects.

- If `[SW]` doesn't exist, the tool will now strip off the square brackets and use `SW` if that exists.
- If the configured component(s) don't exist in your Jira project, a clean warning will be logged. `WARNING: Invalid components found for project SWDT: '[SWW]'` and a JIRAError will be avoided. The happy flow will continue since the addition of a component is not crucial imo.