### PR TITLE
Fix setting of assignee

### DIFF
--- a/mlx/jira_traceability/jira_interaction.py
+++ b/mlx/jira_traceability/jira_interaction.py
@@ -168,13 +168,13 @@ def push_item_to_jira(jira, fields, item, attendees, assignee):
             # Let the JIRA library handle user resolution automatically
             jira.add_watcher(issue, attendee)
         except JIRAError as err:
-            LOGGER.warning("Could not add watcher '{}' to issue {}: {}".format(attendee, issue.key, err.text))
+            LOGGER.warning("Could not add watcher {} to issue {}: {}".format(attendee, issue.key, err.text))
     if assignee:
         try:
             # Let the JIRA library handle user resolution automatically
             jira.assign_issue(issue, assignee)
         except JIRAError as err:
-            LOGGER.warning("Could not assign issue {} to '{}': {}".format(issue.key, assignee, err.text))
+            LOGGER.warning("Could not assign issue {} to {}: {}".format(issue.key, assignee, err.text))
     return issue
 
 


### PR DESCRIPTION
The dependency 'jira' will resolve a username to an account ID. We must not do this ourselves. We must not pass an account ID to 'jira'. https://jira.readthedocs.io/api.html#jira.client.JIRA.assign_issue

This is subject to change perhaps, where it will accept both account ID and username.