### PR TITLE
Add user_email_suffix configuration option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ Configuration
         'warn_if_exists': False,
         'errors_to_warnings': True,
         'notify_watchers': False,
+        'user_email_suffix': '@anotherexample.com'
     }
 
 Jira Configuration
@@ -107,6 +108,12 @@ a ticket for does not have a body, its caption will be used to build the ticket'
 Watchers of a ticket can be notified about the creation of the ticket by setting ``notify_watchers`` to ``True``.
 Note that this notification is only sent when the user to assign to the ticket is different from the default assignee
 configured in Jira.
+
+``user_email_suffix`` can be used to specify a custom domain suffix for Jira user emails (assignee, watchers).
+If set, this suffix will be appended to usernames that do not already contain an '@' symbol.
+This setting overrides the default behavior of extracting the suffix from the ``username`` configured in Jira Server
+or Jira Cloud settings. This helps for example when using a service account as the Jira username that has a different
+domain than the users.
 
 Attributes
 ==========

--- a/mlx/jira_traceability/jira_interaction.py
+++ b/mlx/jira_traceability/jira_interaction.py
@@ -73,9 +73,17 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
         assignee = item.get_attribute('assignee').strip()
         attendees, jira_field = get_info_from_relationship(item, settings['relationship_to_parent'],
                                                            traceability_collection)
-        username = settings['username']
-        if '@' in username:
-            suffix = username[username.index('@'):]
+        user_email_suffix = settings.get('user_email_suffix', '')
+        if user_email_suffix:
+            suffix = user_email_suffix if user_email_suffix.startswith('@') else f"@{user_email_suffix}"
+        else:
+            username = settings['username']
+            if '@' in username:
+                suffix = username[username.index('@'):]
+            else:
+                suffix = ''
+
+        if suffix:
             assignee = f"{assignee}{suffix}".lower()
             attendees = [f"{attendee}{suffix}".lower() for attendee in attendees]
 

--- a/mlx/jira_traceability/jira_interaction.py
+++ b/mlx/jira_traceability/jira_interaction.py
@@ -84,7 +84,8 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
                 suffix = ''
 
         if suffix:
-            assignee = f"{assignee}{suffix}".lower() if '@' not in assignee else assignee
+            if assignee and '@' not in assignee:
+                assignee = f"{assignee}{suffix}".lower()
             attendees = [f"{attendee}{suffix}".lower() if '@' not in attendee else attendee for attendee in attendees]
 
         jira_field_id = settings['jira_field_id']

--- a/mlx/jira_traceability/jira_interaction.py
+++ b/mlx/jira_traceability/jira_interaction.py
@@ -84,8 +84,8 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
                 suffix = ''
 
         if suffix:
-            assignee = f"{assignee}{suffix}".lower()
-            attendees = [f"{attendee}{suffix}".lower() for attendee in attendees]
+            assignee = f"{assignee}{suffix}".lower() if '@' not in assignee else assignee
+            attendees = [f"{attendee}{suffix}".lower() if '@' not in attendee else attendee for attendee in attendees]
 
         jira_field_id = settings['jira_field_id']
         jira_field_query_value = escape_special_characters(jira_field)

--- a/mlx/jira_traceability/jira_interaction.py
+++ b/mlx/jira_traceability/jira_interaction.py
@@ -86,7 +86,8 @@ def create_unique_issues(item_ids, jira, general_fields, settings, traceability_
         if suffix:
             if assignee and '@' not in assignee:
                 assignee = f"{assignee}{suffix}".lower()
-            attendees = [f"{attendee}{suffix}".lower() if '@' not in attendee else attendee for attendee in attendees]
+            attendees = [f"{attendee}{suffix}".lower() if '@' not in attendee else attendee for attendee in attendees
+                         if attendee]
 
         jira_field_id = settings['jira_field_id']
         jira_field_query_value = escape_special_characters(jira_field)

--- a/tests/test_jira_interaction.py
+++ b/tests/test_jira_interaction.py
@@ -571,3 +571,23 @@ class TestJiraInteraction(TestCase):
                                  maxResults=1),
                              mock.call(jql_str="project=MLX12345 and summary ~ 'Caption for action 2'", maxResults=1),
                          ])
+
+    def test_user_email_suffix(self, jira):
+        """ Test that the user_email_suffix configuration is correctly used """
+        self.settings['user_email_suffix'] = 'mycompany.com'
+        self.settings['notify_watchers'] = True  # To trigger assign_issue
+        jira_mock = jira.return_value
+        jira_mock.enhanced_search_issues.return_value = []
+        jira_mock.project_components.return_value = produce_fake_components()
+        jira_mock.search_users.return_value = True
+
+        dut.create_jira_issues(self.settings, self.coll)
+
+        # Check that add_watcher and assign_issue were called with the correct email addresses
+        expected_watchers = ['abc@mycompany.com', 'zzz@mycompany.com']
+        for call in jira_mock.add_watcher.call_args_list:
+            self.assertIn(call.args[1], expected_watchers)
+
+        expected_assignees = ['abc@mycompany.com', 'zzz@mycompany.com']
+        for call in jira_mock.assign_issue.call_args_list:
+            self.assertIn(call.args[1], expected_assignees)


### PR DESCRIPTION
Since moving to service accounts, the tool has been generating incorrect watcher emails. This leads to JiraErrors because the system cannot find a matching user. Making the email suffix configurable will fix this by ensuring the watcher's email is formatted correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional configurable email suffix for Jira assignees and watchers; normalized and only appended when an identifier lacks an email address.

* **Tests**
  * Added unit test verifying the custom email suffix is applied for assignments and watcher notifications.

* **Documentation**
  * README updated to document the new user_email_suffix configuration and its precedence over previous suffix derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->